### PR TITLE
Simplified the Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,9 @@ language: php
 
 php: [5.3.3, 5.3, 5.4, 5.5]
 
-env:
-  - LIBRABBITMQ_VERSION=master
-  - LIBRABBITMQ_VERSION=v0.5.0
-
 services: rabbitmq
 
 before_script:
-  - sh -c "git clone git://github.com/alanxz/rabbitmq-c.git"
-  - sh -c "cd rabbitmq-c && git checkout ${LIBRABBITMQ_VERSION}"
-  - sh -c "cd rabbitmq-c && git submodule init && git submodule update"
-  - sh -c "cd rabbitmq-c && autoreconf -i && ./configure && make && sudo make install"
   - echo "extension=amqp.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
   - composer selfupdate
   - composer install --prefer-source


### PR DESCRIPTION
SwarrotBundle does not perform rabbitmq calls in its testsuite, so it is not necessary to use different librabbitmq versions.
this makes the Travis build faster by using only 4 jobs rather than 8 (a github orga can only run 5 concurrent jobs on Travis currently)

thus, I'm not even sure it was actually using different versions of librabbitmq as the conf uses the precompiled amqp extension available on Travis, which probably links against a librabbitmq installed elsewhere
