### PR TITLE
Improved the travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
-php: [5.4, 5.5]
+php: [5.4, 5.5, 5.6]
 
-services: rabbitmq
-
-before_script:
+before_install:
   - echo "extension=amqp.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
   - composer selfupdate
-  - composer install --prefer-source
+
+install:
+  - composer install --prefer-source -n


### PR DESCRIPTION
- added testing on PHP 5.6
- remove the starting of the RabbitMQ server as it is not used bby the testsuite
- move the composer installation to the install section for forward-compatibility. There are discussion on Travis to run composer by default for PHP project as the `install` step. Overwriting the install step to run it ensures that composer does not run twice once the change is merged and deployed on Travis (at this time, it will be possible to remove the install section from the config to rely on the default)
