### PR TITLE
Improve the config for the provider

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -33,7 +33,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('provider')
                     ->defaultValue('pecl')
-                    ->isRequired()
+                    ->cannotBeEmpty()
                 ->end()
                 ->scalarNode('default_connection')->defaultValue(null)->end()
                 ->scalarNode('default_command')->defaultValue('swarrot.command.base')->cannotBeEmpty()->end()


### PR DESCRIPTION
Marking a node as required makes the default value useless.