### PR TITLE
Change the default port to match the RabbitMQ default value

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -44,7 +44,7 @@ class Configuration implements ConfigurationInterface
                     ->prototype('array')
                         ->children()
                             ->scalarNode('host')->defaultValue('127.0.0.1')->cannotBeEmpty()->end()
-                            ->integerNode('port')->defaultValue(6379)->cannotBeEmpty()->end()
+                            ->integerNode('port')->defaultValue(5672)->cannotBeEmpty()->end()
                             ->scalarNode('login')->defaultValue('guest')->cannotBeEmpty()->end()
                             ->scalarNode('password')->defaultValue('guest')->end()
                             ->scalarNode('vhost')->defaultValue('/')->cannotBeEmpty()->end()


### PR DESCRIPTION
This is technically a BC break, but it makes the bundle much easier to use.