### PR TITLE
Decouple the activation of the collector from the debug mode

### DIFF
--- a/DataCollector/SwarrotDataCollector.php
+++ b/DataCollector/SwarrotDataCollector.php
@@ -9,8 +9,6 @@ use Swarrot\SwarrotBundle\Event\MessagePublishedEvent;
 
 class SwarrotDataCollector extends DataCollector
 {
-    protected $data = array();
-
     /**
      * {@inheritDoc}
      */

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,6 +17,13 @@ class Configuration implements ConfigurationInterface
         'object_manager'     => 'Swarrot\Processor\Doctrine\ObjectManagerProcessor',
     );
 
+    private $debug;
+
+    public function __construct($debug)
+    {
+        $this->debug = $debug;
+    }
+
     /**
      * Generates the configuration tree.
      *
@@ -106,6 +113,7 @@ class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('name')
                     ->prototype('scalar')->isRequired()->end()
                 ->end()
+                ->booleanNode('enable_collector')->defaultValue($this->debug)->end()
             ->end()
         ;
 

--- a/DependencyInjection/SwarrotExtension.php
+++ b/DependencyInjection/SwarrotExtension.php
@@ -5,9 +5,7 @@ namespace Swarrot\SwarrotBundle\DependencyInjection;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 
@@ -21,10 +19,7 @@ class SwarrotExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $processor = new Processor();
-        $configuration = new Configuration();
-
-        $config = $processor->processConfiguration($configuration, $configs);
+        $config = $this->processConfiguration($this->getConfiguration($configs, $container), $configs);
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('swarrot.xml');
@@ -75,9 +70,17 @@ class SwarrotExtension extends Extension
 
         $container->setParameter('swarrot.messages_types', $messagesTypes);
 
-        if ($container->getParameter('kernel.debug')) {
+        if ($config['enable_collector']) {
             $loader->load('collector.xml');
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfiguration(array $configs, ContainerBuilder $container)
+    {
+        return new Configuration($container->getParameter('kernel.debug'));
     }
 
     /**

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -10,7 +10,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf(
             'Swarrot\SwarrotBundle\DependencyInjection\Configuration',
-            new Configuration()
+            new Configuration(false)
         );
     }
 }

--- a/Tests/DependencyInjection/SwarrotExtensionTest.php
+++ b/Tests/DependencyInjection/SwarrotExtensionTest.php
@@ -3,6 +3,7 @@
 namespace Swarrot\SwarrotBundle\Tests\DependencyInjection;
 
 use Swarrot\SwarrotBundle\DependencyInjection\SwarrotExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class SwarrotExtensionTest extends \PHPUnit_Framework_TestCase
 {
@@ -12,5 +13,72 @@ class SwarrotExtensionTest extends \PHPUnit_Framework_TestCase
             'Swarrot\SwarrotBundle\DependencyInjection\SwarrotExtension',
             new SwarrotExtension()
         );
+    }
+
+    public function test_it_registers_the_collector_by_default_in_debug_mode()
+    {
+        $container = $this->createContainer();
+
+        $this->loadConfig($container);
+
+        $this->assertHasService($container, 'swarrot.data_collector');
+    }
+
+    public function test_it_does_not_register_the_collector_by_default_in_non_debug_mode()
+    {
+        $container = $this->createContainer(false);
+
+        $this->loadConfig($container);
+
+        $this->assertNotHasService($container, 'swarrot.data_collector');
+    }
+
+    public function test_it_does_not_register_the_collector_when_explicitly_disabled()
+    {
+        $container = $this->createContainer();
+
+        $this->loadConfig($container, array('enable_collector' => false));
+
+        $this->assertNotHasService($container, 'swarrot.data_collector');
+    }
+
+    public function test_it_registers_the_collector_when_explicitly_enabled()
+    {
+        $container = $this->createContainer(false);
+
+        $this->loadConfig($container, array('enable_collector' => true));
+
+        $this->assertHasService($container, 'swarrot.data_collector');
+    }
+
+    private function assertHasService(ContainerBuilder $container, $id)
+    {
+        $this->assertTrue($container->hasDefinition($id) || $container->hasAlias($id), sprintf('The service %s should be defined.', $id));
+    }
+
+    private function assertNotHasService(ContainerBuilder $container, $id)
+    {
+        $this->assertFalse($container->hasDefinition($id) || $container->hasAlias($id), sprintf('The service %s should not be defined.', $id));
+    }
+
+    private function loadConfig(ContainerBuilder $container, array $config = array())
+    {
+        // Minimal config required by the Configuration class
+        $defaultConfig = array(
+            'provider' => 'pecl',
+            'connections' => array('default' => null),
+        );
+
+        $extension = new SwarrotExtension();
+
+        $extension->load(array($defaultConfig, $config), $container);
+    }
+
+    private function createContainer($debug = true)
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', $debug);
+
+        return $container;
     }
 }


### PR DESCRIPTION
In some cases, it is useful to enable the collector in non-debug mode or to disable it in debug mode. Providing an explicit configuration (defaulting to the debug mode) allows this.