### PR TITLE
use extra from config.yml as default value for options

### DIFF
--- a/Command/SwarrotCommand.php
+++ b/Command/SwarrotCommand.php
@@ -59,13 +59,28 @@ class SwarrotCommand extends ContainerAwareCommand
         ;
 
         if (array_key_exists('ack', $this->processorStack)) {
-            $this->addOption('requeue-on-error', 'r', InputOption::VALUE_NONE, 'Requeue in the same queue on error');
+            $this->addOption(
+                'requeue-on-error',
+                'r',
+                InputOption::VALUE_OPTIONAL,
+                'Requeue in the same queue on error',
+                (isset($this->extras['requeue_on_error']))?$this->extras['requeue_on_error']:false);
         }
         if (array_key_exists('max_execution_time', $this->processorStack)) {
-            $this->addOption('max-execution-time', 't', InputOption::VALUE_REQUIRED, 'Max execution time (seconds) before exit', 300);
+            $this->addOption(
+                'max-execution-time',
+                't',
+                InputOption::VALUE_REQUIRED,
+                'Max execution time (seconds) before exit',
+                (isset($this->extras['max_execution_time']))?$this->extras['max_execution_time']:300);
         }
         if (array_key_exists('max_messages', $this->processorStack)) {
-            $this->addOption('max-messages', 'm', InputOption::VALUE_REQUIRED, 'Max messages to process before exit', 300);
+            $this->addOption(
+                'max-messages',
+                'm',
+                InputOption::VALUE_REQUIRED,
+                'Max messages to process before exit',
+                (isset($this->extras['max_messages']))?$this->extras['max_messages']:300);
         }
         if (array_key_exists('exception_catcher', $this->processorStack)) {
             $this->addOption('no-catch', 'C', InputOption::VALUE_NONE, 'Deactivate exception catching.');
@@ -75,7 +90,12 @@ class SwarrotCommand extends ContainerAwareCommand
         }
         if (array_key_exists('retry', $this->processorStack)) {
             $this->addOption('no-retry', 'R', InputOption::VALUE_NONE, 'Deactivate retry.');
-            $this->addOption('retry-attempts', null, InputOption::VALUE_REQUIRED, 'Number of maximum retry attempts (if it exists, override the extra data parameter)');
+            $this->addOption(
+                'retry-attempts',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Number of maximum retry attempts (if it exists, override the extra data parameter)',
+                (isset($this->extras['retry_attempts']))?$this->extras['retry_attempts']:3);
         }
     }
 
@@ -166,11 +186,7 @@ class SwarrotCommand extends ContainerAwareCommand
             $options['retry_key_pattern'] = $key;
 
             $attempts = 3;
-            if (isset($this->extras['retry_attempts'])) {
-                $attempts = $this->extras['retry_attempts'];
-            }
-
-            if (null !== $input->getOption('retry-attempts')) {
+            if ($input->hasOption('retry-attempts')) {
                 $attempts = (int) $input->getOption('retry-attempts');
             }
             $options['retry_attempts'] = $attempts;

--- a/Command/SwarrotCommand.php
+++ b/Command/SwarrotCommand.php
@@ -175,7 +175,9 @@ class SwarrotCommand extends ContainerAwareCommand
             $options['max_messages'] = (int) $input->getOption('max-messages');
         }
 
-        $options['requeue_on_error'] = ((isset($this->extras['requeue_on_error']) && true == $this->extras['requeue_on_error']) || (true === $input->getOption('requeue-on-error')));
+        if (array_key_exists('ack', $this->processorStack)) {
+            $options['requeue_on_error'] = ((isset($this->extras['requeue_on_error']) && true == $this->extras['requeue_on_error']) || (true === $input->getOption('requeue-on-error')));
+        }
 
         if (array_key_exists('retry', $this->processorStack) && !$input->getOption('no-retry')) {
             $key = 'retry_%attempt%s';

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ swarrot:
         my_consumer:
             processor: my_consumer.processor.service
             extras:
+                poll_interval: 500000
                 retry_exchange: my_consumer_exchange
                 retry_attempts: 3
                 retry_routing_key_pattern: 'retry_%%attempt%%'
@@ -133,7 +134,25 @@ here is the default order:
 * Ack
 * Retry
 
-All this processors are configurable with some options:
+All this processors are configurable.
+You can add `extras` key on each consumer definition in your `config.yml`
+
+```
+swarrot:
+    ...
+    consumers:
+        my_consumer:
+            processor: my_consumer.processor.service
+            extras:
+                poll_interval: 500000
+                requeue_on_error: 1
+                max_messages: 10
+                retry_exchange: my_consumer_exchange
+                retry_attempts: 3
+                retry_routing_key_pattern: 'retry_%%attempt%%'
+```
+ 
+You can also use options of the commande line:
 
 * **--poll-interval** [default: 500000]: Change the polling interval when no
   message found in broker
@@ -148,16 +167,18 @@ All this processors are configurable with some options:
 * **--no-retry (-R)**: Disable the Retry processor (available only if the processor
   is in the stack)
 
+Default values will be override by your `config.yml` and use of options will override defaut|config values.
+
 ## Running your tests without publishing
 If you use Swarrot you may not want to realy publish  messages like in test environment for example. You can use the `BlackholePublisher` to achieve this.
 
-Simply override the `swarrot.publisher.class` parameter in the DIC with the `Swarrot\SwarrotBundle\Broker\BlackholePublisher` class.
+Simply override the `swarrot.publisher.class` parameter in the DIC with the `Swarrot\SwarrotBundle\Broker\PublisherBlackhole` class.
 
 Update `config_test.yml` for example:
 
 ```yaml
 parameters:
-    swarrot.publisher.class: SP\Utils\Swarrot\BlackholePublisher
+    swarrot.publisher.class: SP\Utils\Swarrot\PublisherBlackhole
 ```
 
 ## License


### PR DESCRIPTION
fix bug where config from config.yml is unused in the command.
my config:

    processors_stack:
        ack: 'Swarrot\Processor\Ack\AckProcessor'
        max_messages: 'Swarrot\Processor\MaxMessages\MaxMessagesProcessor'
        exception_catcher: 'Swarrot\Processor\ExceptionCatcher\ExceptionCatcherProcessor'
        max_execution_time: 'Swarrot\Processor\MaxExecutionTime\MaxExecutionTimeProcessor'
    consumers:
        esign_start:
            processor: async_esignature.processors.validator_message.esign_start
            extras:
                requeue_on_error: 1
                max_execution_time: 1000

I call consumer with command line:

    php app/console swarrot:consume:esign_start esign_start -m 1

Without override requeue_on_error and max_execution_time on command line I get requeue_on_error = false and max_execute_time = 300 as arguments ofprocessor.

I modified to use value in $extras coming from config.yml as default value if the option exists.
Change the same way for retry-attemps and clean deplicate code.