### PR TITLE
Move Provider logic in a compilerpass

### DIFF
--- a/DependencyInjection/Compiler/ProviderCompilerPass.php
+++ b/DependencyInjection/Compiler/ProviderCompilerPass.php
@@ -30,7 +30,9 @@ class ProviderCompilerPass implements CompilerPassInterface
 
         $id = $providersIds[$provider];
         $definition = $container->getDefinition($id);
-        $reflection = new \ReflectionClass($definition->getClass());
+        $className = $container->getParameterBag()->resolveValue($definition->getClass());
+
+        $reflection = new \ReflectionClass($className);
 
         if (!$reflection->implementsInterface('Swarrot\\SwarrotBundle\\Broker\\FactoryInterface')) {
             throw new \InvalidArgumentException(sprintf('The provider "%s" is not valid', $provider));

--- a/DependencyInjection/Compiler/ProviderCompilerPass.php
+++ b/DependencyInjection/Compiler/ProviderCompilerPass.php
@@ -18,7 +18,12 @@ class ProviderCompilerPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds('swarrot.provider_factory') as $id => $tags) {
             foreach ($tags as $tag) {
-                $providersIds[isset($tag['alias']) ? $tag['alias'] : $id] = $id;
+                if (!isset($tag['alias'])) {
+                    throw new \InvalidArgumentException(
+                        sprintf('The provider\'s alias is no defined for the service "%s"', $id)
+                    );
+                }
+                $providersIds[$tag['alias']] = $id;
             }
         }
 

--- a/DependencyInjection/Compiler/ProviderCompilerPass.php
+++ b/DependencyInjection/Compiler/ProviderCompilerPass.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Swarrot\SwarrotBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ProviderCompilerPass implements CompilerPassInterface
+{
+    /** {@inheritDoc} */
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->has('swarrot.factory.default') || !$container->hasParameter('swarrot.provider_config')) {
+            return;
+        }
+
+        $providersIds = [];
+
+        foreach ($container->findTaggedServiceIds('swarrot.provider_factory') as $id => $tags) {
+            foreach ($tags as $tag) {
+                $providersIds[isset($tag['alias']) ? $tag['alias'] : $id] = $id;
+            }
+        }
+
+        list($provider, $connections) = $container->getParameter('swarrot.provider_config');
+
+        if (!isset($providersIds[$provider])) {
+            throw new \InvalidArgumentException(sprintf('Invalid provider "%s"', $provider));
+        }
+
+        $id = $providersIds[$provider];
+        $definition = $container->getDefinition($id);
+        $reflection = new \ReflectionClass($definition->getClass());
+
+        if (!$reflection->implementsInterface('Swarrot\\SwarrotBundle\\Broker\\FactoryInterface')) {
+            throw new \InvalidArgumentException(sprintf('The provider "%s" is not valid', $provider));
+        }
+
+        foreach ($connections as $name => $connectionConfig) {
+            $definition->addMethodCall('addConnection', [
+                $name,
+                $connectionConfig
+            ]);
+        }
+
+        $container->setAlias('swarrot.factory.default', $id);
+        $container->getParameterBag()->remove('swarrot.provider_config');
+    }
+}

--- a/DependencyInjection/SwarrotExtension.php
+++ b/DependencyInjection/SwarrotExtension.php
@@ -24,26 +24,12 @@ class SwarrotExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('swarrot.xml');
 
-        $id = 'swarrot.factory.'.$config['provider'];
-        if (!$container->has($id)) {
-            throw new \InvalidArgumentException('Unsupported provider');
-        }
-
-        $definition = $container->getDefinition($id);
-
-        foreach ($config['connections'] as $name => $connectionConfig) {
-            $definition->addMethodCall('addConnection', array(
-                $name,
-                $connectionConfig
-            ));
-        }
-
         if (null === $config['default_connection']) {
             reset($config['connections']);
             $config['default_connection'] = key($config['connections']);
         }
 
-        $container->setAlias('swarrot.factory.default', $id);
+        $container->setParameter('swarrot.provider_config', [$config['provider'], $config['connections']]);
 
         $commands = array();
         foreach ($config['consumers'] as $name => $consumerConfig) {

--- a/README.md
+++ b/README.md
@@ -169,6 +169,38 @@ You can also use options of the commande line:
 
 Default values will be override by your `config.yml` and use of options will override defaut|config values.
 
+## Implementing your own Provider
+If you want to implement your own provider (like Redis). First, you have to implements the `Swarrot\SwarrotBundle\Broker\FactoryInterface`.
+Then, you can register it with along the others services and tag it with `swarrot.provider_factory`. 
+
+```yaml
+services:
+    app.swarrot.custom_provider_factory:
+        class: AppBundle\Provider\CustomFactory
+        tags:
+            - {name: swarrot.provider_factory}
+    app.swarrot.redis_provider_factory:
+        class: AppBundle\Provider\RedisFactory
+        tags:
+            - {name: swarrot.provider_factory, alias: redis}
+```
+
+Now you can tell to swarrot to use it in the `config.yml` file.
+
+```yaml
+swarrot:
+  provider: app.swarrot.custom_provider_factory
+  ...
+```
+
+or with the alias
+
+```yaml
+swarrot:
+  provider: redis
+  ...
+```
+
 ## Running your tests without publishing
 If you use Swarrot you may not want to realy publish  messages like in test environment for example. You can use the `BlackholePublisher` to achieve this.
 

--- a/Resources/config/swarrot.xml
+++ b/Resources/config/swarrot.xml
@@ -10,8 +10,12 @@
     </parameters>
 
     <services>
-        <service id="swarrot.factory.pecl" class="%swarrot.factory.pecl.class%" />
-        <service id="swarrot.factory.amqp_lib" class="%swarrot.factory.amqp_lib.class%" />
+        <service id="swarrot.factory.pecl" class="%swarrot.factory.pecl.class%">
+            <tag name="swarrot.provider_factory" alias="pecl"/>
+        </service>
+        <service id="swarrot.factory.amqp_lib" class="%swarrot.factory.amqp_lib.class%">
+            <tag name="swarrot.provider_factory" alias="amqp_lib"/>
+        </service>
 
         <service id="swarrot.command.base" class="%swarrot.command.base.class%" abstract="true">
             <argument /> <!-- name -->

--- a/SwarrotBundle.php
+++ b/SwarrotBundle.php
@@ -2,11 +2,20 @@
 
 namespace Swarrot\SwarrotBundle;
 
-use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Swarrot\SwarrotBundle\DependencyInjection\Compiler\ProviderCompilerPass;
 use Symfony\Component\Console\Application;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class SwarrotBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new ProviderCompilerPass());
+    }
+
     public function registerCommands(Application $application)
     {
         $container = $application->getKernel()->getContainer();

--- a/Tests/DependencyInjection/Compiler/ProviderCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ProviderCompilerPassTest.php
@@ -63,6 +63,45 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException        InvalidArgumentException
+     * @expectedExceptionMessage The provider's alias is no defined for the service "foo"
+     */
+    public function test_missing_alias()
+    {
+        $container = $this->getContainer();
+
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('swarrot.factory.default')
+            ->willReturn(false)
+        ;
+        $container
+            ->expects($this->once())
+            ->method('hasParameter')
+            ->with('swarrot.provider_config')
+            ->willReturn(true)
+        ;
+        $container
+            ->expects($this->once())
+            ->method('findTaggedServiceIds')
+            ->with('swarrot.provider_factory')
+            ->willReturn([
+                'foo' => [
+                    []
+                ]
+            ])
+        ;
+
+        $container->expects($this->never())->method('getParameter');
+        $container->expects($this->never())->method('setAlias');
+        $container->expects($this->never())->method('getDefinition');
+
+        $compiler = new ProviderCompilerPass;
+        $compiler->process($container);
+    }
+
+    /**
+     * @expectedException        InvalidArgumentException
      * @expectedExceptionMessage Invalid provider "foo"
      */
     public function test_unexistant_provider()
@@ -92,7 +131,9 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
                     ]
                 ],
                 'bar' => [
-                    []
+                    [
+                        'alias' => 'bar'
+                    ]
                 ]
             ])
         ;
@@ -159,7 +200,9 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
                     ]
                 ],
                 'bar' => [
-                    []
+                    [
+                        'alias' => 'bar'
+                    ]
                 ]
             ])
         ;
@@ -230,7 +273,9 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
                     ]
                 ],
                 'bar' => [
-                    []
+                    [
+                        'alias' => 'bar'
+                    ]
                 ]
             ])
         ;

--- a/Tests/DependencyInjection/Compiler/ProviderCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ProviderCompilerPassTest.php
@@ -16,7 +16,15 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
 
     public function test_should_not_run_if_already_declared()
     {
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder');
+        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder', [
+            'has',
+            'setAlias',
+            'hasParameter',
+            'getParameter',
+            'getDefinition',
+            'getParameterBag',
+            'findTaggedServiceIds',
+        ]);
 
         $container
             ->expects($this->once())
@@ -38,7 +46,15 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
 
     public function test_should_not_run_if_not_configured()
     {
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder');
+        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder', [
+            'has',
+            'setAlias',
+            'hasParameter',
+            'getParameter',
+            'getDefinition',
+            'getParameterBag',
+            'findTaggedServiceIds',
+        ]);
 
         $container
             ->expects($this->once())
@@ -69,7 +85,15 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
      */
     public function test_unexistant_provider()
     {
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder');
+        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder', [
+            'has',
+            'setAlias',
+            'hasParameter',
+            'getParameter',
+            'getDefinition',
+            'getParameterBag',
+            'findTaggedServiceIds',
+        ]);
 
         $container
             ->expects($this->once())
@@ -122,7 +146,15 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
      */
     public function test_invalid_provider()
     {
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder');
+        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder', [
+            'has',
+            'setAlias',
+            'hasParameter',
+            'getParameter',
+            'getDefinition',
+            'getParameterBag',
+            'findTaggedServiceIds',
+        ]);
         $definition = $this->getMock('Symfony\\Component\\DependencyInjection\\Definition');
 
         $definition->expects($this->once())
@@ -185,7 +217,15 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
 
     public function test_successful_provider()
     {
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder');
+        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder', [
+            'has',
+            'setAlias',
+            'hasParameter',
+            'getParameter',
+            'getDefinition',
+            'getParameterBag',
+            'findTaggedServiceIds',
+        ]);
         $definition = $this->getMock('Symfony\\Component\\DependencyInjection\\Definition');
         $parameterBag = $this->getMock('Symfony\\Component\\DependencyInjection\\ParameterBag\\ParameterBag');
 

--- a/Tests/DependencyInjection/Compiler/ProviderCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ProviderCompilerPassTest.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace Swarrot\SwarrotBundle\Tests\DependencyInjection\Compiler;
+
+use Swarrot\SwarrotBundle\DependencyInjection\Compiler\ProviderCompilerPass;
+
+class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_it_is_initializable()
+    {
+        $this->assertInstanceOf(
+            'Swarrot\\SwarrotBundle\\DependencyInjection\\Compiler\\ProviderCompilerPass',
+            new ProviderCompilerPass()
+        );
+    }
+
+    public function test_should_not_run_if_already_declared()
+    {
+        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder');
+
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('swarrot.factory.default')
+            ->willReturn(true)
+        ;
+
+        $container->expects($this->never())->method('setAlias');
+        $container->expects($this->never())->method('hasParameter');
+        $container->expects($this->never())->method('getParameter');
+        $container->expects($this->never())->method('getDefinition');
+        $container->expects($this->never())->method('getParameterBag');
+        $container->expects($this->never())->method('findTaggedServiceIds');
+
+        $compiler = new ProviderCompilerPass;
+        $compiler->process($container);
+    }
+
+    public function test_should_not_run_if_not_configured()
+    {
+        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder');
+
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('swarrot.factory.default')
+            ->willReturn(false)
+        ;
+        $container
+            ->expects($this->once())
+            ->method('hasParameter')
+            ->with('swarrot.provider_config')
+            ->willReturn(false)
+        ;
+
+        $container->expects($this->never())->method('setAlias');
+        $container->expects($this->never())->method('getParameter');
+        $container->expects($this->never())->method('getDefinition');
+        $container->expects($this->never())->method('getParameterBag');
+        $container->expects($this->never())->method('findTaggedServiceIds');
+
+        $compiler = new ProviderCompilerPass;
+        $compiler->process($container);
+    }
+
+    /**
+     * @expectedException        InvalidArgumentException
+     * @expectedExceptionMessage Invalid provider "foo"
+     */
+    public function test_unexistant_provider()
+    {
+        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder');
+
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('swarrot.factory.default')
+            ->willReturn(false)
+        ;
+        $container
+            ->expects($this->once())
+            ->method('hasParameter')
+            ->with('swarrot.provider_config')
+            ->willReturn(true)
+        ;
+        $container
+            ->expects($this->once())
+            ->method('findTaggedServiceIds')
+            ->with('swarrot.provider_factory')
+            ->willReturn([
+                'foo' => [
+                    [
+                        'alias' => 'foo.bar'
+                    ]
+                ],
+                'bar' => [
+                    []
+                ]
+            ])
+        ;
+        $container
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with('swarrot.provider_config')
+            ->willReturn([
+                'foo',
+                []
+            ])
+        ;
+
+        $container->expects($this->never())->method('setAlias');
+        $container->expects($this->never())->method('getDefinition');
+        $container->expects($this->never())->method('getParameterBag');
+
+        $compiler = new ProviderCompilerPass;
+        $compiler->process($container);
+    }
+
+    /**
+     * @expectedException        InvalidArgumentException
+     * @expectedExceptionMessage The provider "foo.bar" is not valid
+     */
+    public function test_invalid_provider()
+    {
+        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder');
+        $definition = $this->getMock('Symfony\\Component\\DependencyInjection\\Definition');
+
+        $definition->expects($this->once())
+                   ->method('getClass')
+                   ->with()
+                   ->willReturn('stdClass')
+        ;
+
+        $definition->expects($this->never())->method('addMethodCall');
+
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('swarrot.factory.default')
+            ->willReturn(false)
+        ;
+        $container
+            ->expects($this->once())
+            ->method('hasParameter')
+            ->with('swarrot.provider_config')
+            ->willReturn(true)
+        ;
+        $container
+            ->expects($this->once())
+            ->method('findTaggedServiceIds')
+            ->with('swarrot.provider_factory')
+            ->willReturn([
+                'foo' => [
+                    [
+                        'alias' => 'foo.bar'
+                    ]
+                ],
+                'bar' => [
+                    []
+                ]
+            ])
+        ;
+        $container
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with('swarrot.provider_config')
+            ->willReturn([
+                'foo.bar',
+                []
+            ])
+        ;
+        $container
+            ->expects($this->once())
+            ->method('getDefinition')
+            ->with('foo')
+            ->willReturn($definition)
+        ;
+
+        $container->expects($this->never())->method('setAlias');
+        $container->expects($this->never())->method('getParameterBag');
+
+        $compiler = new ProviderCompilerPass;
+        $compiler->process($container);
+    }
+
+    public function test_successful_provider()
+    {
+        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder');
+        $definition = $this->getMock('Symfony\\Component\\DependencyInjection\\Definition');
+        $parameterBag = $this->getMock('Symfony\\Component\\DependencyInjection\\ParameterBag\\ParameterBag');
+
+        $definition->expects($this->once())
+                   ->method('getClass')
+                   ->with()
+                   ->willReturn('Swarrot\\SwarrotBundle\\Broker\\FactoryInterface')
+        ;
+        $definition->expects($this->once())
+                   ->method('addMethodCall')
+                   ->with('addConnection', ['foo', []])
+        ;
+
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('swarrot.factory.default')
+            ->willReturn(false)
+        ;
+        $container
+            ->expects($this->once())
+            ->method('hasParameter')
+            ->with('swarrot.provider_config')
+            ->willReturn(true)
+        ;
+        $container
+            ->expects($this->once())
+            ->method('findTaggedServiceIds')
+            ->with('swarrot.provider_factory')
+            ->willReturn([
+                'foo' => [
+                    [
+                        'alias' => 'foo.bar'
+                    ]
+                ],
+                'bar' => [
+                    []
+                ]
+            ])
+        ;
+        $container
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with('swarrot.provider_config')
+            ->willReturn([
+                'foo.bar',
+                [
+                    'foo' => []
+                ]
+            ])
+        ;
+        $container
+            ->expects($this->once())
+            ->method('getDefinition')
+            ->with('foo')
+            ->willReturn($definition)
+        ;
+        $container
+            ->expects($this->once())
+            ->method('setAlias')
+            ->with('swarrot.factory.default', 'foo')
+        ;
+        $container
+            ->expects($this->once())
+            ->method('getParameterBag')
+            ->willReturn($parameterBag)
+        ;
+
+        $parameterBag
+            ->expects($this->once())
+            ->method('remove')
+            ->with('swarrot.provider_config')
+        ;
+
+        $compiler = new ProviderCompilerPass;
+        $compiler->process($container);;
+    }
+}

--- a/Tests/DependencyInjection/Compiler/ProviderCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ProviderCompilerPassTest.php
@@ -16,15 +16,7 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
 
     public function test_should_not_run_if_already_declared()
     {
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder', [
-            'has',
-            'setAlias',
-            'hasParameter',
-            'getParameter',
-            'getDefinition',
-            'getParameterBag',
-            'findTaggedServiceIds',
-        ]);
+        $container = $this->getContainer();
 
         $container
             ->expects($this->once())
@@ -37,7 +29,6 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
         $container->expects($this->never())->method('hasParameter');
         $container->expects($this->never())->method('getParameter');
         $container->expects($this->never())->method('getDefinition');
-        $container->expects($this->never())->method('getParameterBag');
         $container->expects($this->never())->method('findTaggedServiceIds');
 
         $compiler = new ProviderCompilerPass;
@@ -46,15 +37,7 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
 
     public function test_should_not_run_if_not_configured()
     {
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder', [
-            'has',
-            'setAlias',
-            'hasParameter',
-            'getParameter',
-            'getDefinition',
-            'getParameterBag',
-            'findTaggedServiceIds',
-        ]);
+        $container = $this->getContainer();
 
         $container
             ->expects($this->once())
@@ -72,7 +55,6 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
         $container->expects($this->never())->method('setAlias');
         $container->expects($this->never())->method('getParameter');
         $container->expects($this->never())->method('getDefinition');
-        $container->expects($this->never())->method('getParameterBag');
         $container->expects($this->never())->method('findTaggedServiceIds');
 
         $compiler = new ProviderCompilerPass;
@@ -85,15 +67,7 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
      */
     public function test_unexistant_provider()
     {
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder', [
-            'has',
-            'setAlias',
-            'hasParameter',
-            'getParameter',
-            'getDefinition',
-            'getParameterBag',
-            'findTaggedServiceIds',
-        ]);
+        $container = $this->getContainer();
 
         $container
             ->expects($this->once())
@@ -134,7 +108,6 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
 
         $container->expects($this->never())->method('setAlias');
         $container->expects($this->never())->method('getDefinition');
-        $container->expects($this->never())->method('getParameterBag');
 
         $compiler = new ProviderCompilerPass;
         $compiler->process($container);
@@ -146,15 +119,7 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
      */
     public function test_invalid_provider()
     {
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder', [
-            'has',
-            'setAlias',
-            'hasParameter',
-            'getParameter',
-            'getDefinition',
-            'getParameterBag',
-            'findTaggedServiceIds',
-        ]);
+        $container = $this->getContainer();
         $definition = $this->getMock('Symfony\\Component\\DependencyInjection\\Definition');
 
         $definition->expects($this->once())
@@ -162,8 +127,14 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
                    ->with()
                    ->willReturn('stdClass')
         ;
-
         $definition->expects($this->never())->method('addMethodCall');
+
+        $container->getParameterBag()
+                  ->expects($this->once())
+                  ->method('resolveValue')
+                  ->with('stdClass')
+                  ->willReturn('stdClass')
+        ;
 
         $container
             ->expects($this->once())
@@ -209,7 +180,6 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
         ;
 
         $container->expects($this->never())->method('setAlias');
-        $container->expects($this->never())->method('getParameterBag');
 
         $compiler = new ProviderCompilerPass;
         $compiler->process($container);
@@ -217,17 +187,8 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
 
     public function test_successful_provider()
     {
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder', [
-            'has',
-            'setAlias',
-            'hasParameter',
-            'getParameter',
-            'getDefinition',
-            'getParameterBag',
-            'findTaggedServiceIds',
-        ]);
+        $container = $this->getContainer();
         $definition = $this->getMock('Symfony\\Component\\DependencyInjection\\Definition');
-        $parameterBag = $this->getMock('Symfony\\Component\\DependencyInjection\\ParameterBag\\ParameterBag');
 
         $definition->expects($this->once())
                    ->method('getClass')
@@ -237,6 +198,13 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
         $definition->expects($this->once())
                    ->method('addMethodCall')
                    ->with('addConnection', ['foo', []])
+        ;
+
+        $container->getParameterBag()
+                  ->expects($this->once())
+                  ->method('resolveValue')
+                  ->with('Swarrot\\SwarrotBundle\\Broker\\FactoryInterface')
+                  ->willReturn('Swarrot\\SwarrotBundle\\Broker\\FactoryInterface')
         ;
 
         $container
@@ -288,19 +256,30 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
             ->method('setAlias')
             ->with('swarrot.factory.default', 'foo')
         ;
+
+        $compiler = new ProviderCompilerPass;
+        $compiler->process($container);;
+    }
+
+    private function getContainer()
+    {
+        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder', [
+            'has',
+            'setAlias',
+            'hasParameter',
+            'getParameter',
+            'getDefinition',
+            'getParameterBag',
+            'findTaggedServiceIds',
+        ]);
+        $parameterBag = $this->getMock('Symfony\\Component\\DependencyInjection\\ParameterBag\\ParameterBag');
+
         $container
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('getParameterBag')
             ->willReturn($parameterBag)
         ;
 
-        $parameterBag
-            ->expects($this->once())
-            ->method('remove')
-            ->with('swarrot.provider_config')
-        ;
-
-        $compiler = new ProviderCompilerPass;
-        $compiler->process($container);;
+        return $container;
     }
 }

--- a/Tests/DependencyInjection/SwarrotExtensionTest.php
+++ b/Tests/DependencyInjection/SwarrotExtensionTest.php
@@ -7,14 +7,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class SwarrotExtensionTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function test_it_rejects_invalid_providers()
-    {
-        $this->loadConfig($this->createContainer(), array('provider' => 'invalid'));
-    }
-
     public function test_it_uses_the_default_connection_for_message_types()
     {
         $container = $this->createContainer();


### PR DESCRIPTION
This PR allow users to define their own Providers.
Fixes #66

Sample of use
```
swarrot:
    provider: redis

services:
    app.swarrot.provider_factory:
        class: AppBundle\Provider\RedisFactory
        tags:
            - {name: swarrot.provider_factory, alias: redis}
```