### PR TITLE
Inject connections into constructor instead of using a method

### DIFF
--- a/Broker/FactoryInterface.php
+++ b/Broker/FactoryInterface.php
@@ -8,16 +8,6 @@ use Swarrot\Broker\MessagePublisher\MessagePublisherInterface;
 interface FactoryInterface
 {
     /**
-     * addConnection
-     *
-     * @param string $name       A name for the connection
-     * @param array  $connection An array containing connection informations
-     *
-     * @return FactoryInterface
-     */
-    public function addConnection($name, array $connection);
-
-    /**
      * getMessageProvider
      *
      * @param string $name       The name of the queue where the MessageProviderInterface will found messages

--- a/Broker/PeclFactory.php
+++ b/Broker/PeclFactory.php
@@ -14,12 +14,9 @@ class PeclFactory implements FactoryInterface
     protected $exchanges         = array();
     protected $amqpConnections   = array();
 
-    /**
-     * {@inheritDoc}
-     */
-    public function addConnection($name, array $connection)
+    public function __construct(array $connections = [])
     {
-        $this->connections[$name] = $connection;
+        $this->connections = $connections;
     }
 
     /**

--- a/DependencyInjection/SwarrotExtension.php
+++ b/DependencyInjection/SwarrotExtension.php
@@ -29,14 +29,10 @@ class SwarrotExtension extends Extension
             throw new \InvalidArgumentException('Unsupported provider');
         }
 
-        $definition = $container->getDefinition($id);
-
         foreach ($config['connections'] as $name => $connectionConfig) {
-            $definition->addMethodCall('addConnection', array(
-                $name,
-                $connectionConfig
-            ));
+            $connections[$name] = $connectionConfig;
         }
+        $container->setParameter('swarrot.connections', $connections);
 
         if (null === $config['default_connection']) {
             reset($config['connections']);

--- a/Resources/config/swarrot.xml
+++ b/Resources/config/swarrot.xml
@@ -10,8 +10,12 @@
     </parameters>
 
     <services>
-        <service id="swarrot.factory.pecl" class="%swarrot.factory.pecl.class%" />
-        <service id="swarrot.factory.amqp_lib" class="%swarrot.factory.amqp_lib.class%" />
+        <service id="swarrot.factory.abstract" abstract="true">
+            <argument>%swarrot.connections%</argument>
+        </service>
+
+        <service id="swarrot.factory.pecl" class="%swarrot.factory.pecl.class%" parent="swarrot.factory.abstract" />
+        <service id="swarrot.factory.amqp_lib" class="%swarrot.factory.amqp_lib.class%" parent="swarrot.factory.abstract" />
 
         <service id="swarrot.command.base" class="%swarrot.command.base.class%" abstract="true">
             <argument /> <!-- name -->


### PR DESCRIPTION
There is no reason to use a `addConnection` instead of pass them directly to the constructor.