### PR TITLE
Inject logger into publisher

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -46,6 +46,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('default_connection')->defaultValue(null)->end()
                 ->scalarNode('default_command')->defaultValue('swarrot.command.base')->cannotBeEmpty()->end()
+                ->scalarNode('publisher_logger')->defaultValue('swarrot.logger.null')->cannotBeEmpty()->end()
                 ->arrayNode('connections')
                     ->isRequired()
                     ->requiresAtLeastOneElement()

--- a/DependencyInjection/SwarrotExtension.php
+++ b/DependencyInjection/SwarrotExtension.php
@@ -29,6 +29,8 @@ class SwarrotExtension extends Extension
             $config['default_connection'] = key($config['connections']);
         }
 
+        $container->setAlias('swarrot.logger', $config['publisher_logger']);
+
         $container->setParameter('swarrot.provider_config', [$config['provider'], $config['connections']]);
 
         $commands = array();

--- a/Resources/config/swarrot.xml
+++ b/Resources/config/swarrot.xml
@@ -34,6 +34,9 @@
             <argument type="service" id="swarrot.factory.default" />
             <argument type="service" id="event_dispatcher" />
             <argument>%swarrot.messages_types%</argument>
+            <argument type="service" id="swarrot.logger" />
         </service>
+
+        <service id="swarrot.logger.null" class="Psr\Log\NullLogger" public="false" />
     </services>
 </container>


### PR DESCRIPTION
Until now, it was not possible to use a logger without creating a CompilerPass.