### PR TITLE
Update suggested dependency, videlalvaro is abandoned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "phpunit/phpunit": "~4.5"
     },
     "suggest": {
-        "videlalvaro/php-amqplib": "Required if using amqp_lib"
+        "php-amqplib/php-amqplib": "Required if using amqp_lib"
     },
     "config": {
         "bin-dir": "bin"


### PR DESCRIPTION
Small change, the videlalvaro/php-amqplib package has been abandoned, and should be replaced with php-amqplib/php-amqplib