### PR TITLE
add factory for sqs provider

### DIFF
--- a/Broker/SqsFactory.php
+++ b/Broker/SqsFactory.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Swarrot\SwarrotBundle\Broker;
+
+use Aws\Sqs\SqsClient;
+use Swarrot\MessageProvider\SqsMessageProvider;
+use Swarrot\Broker\MessageProvider\MessageProviderInterface;
+use Swarrot\Broker\MessagePublisher\MessagePublisherInterface;
+use Swarrot\SwarrotBundle\Broker\FactoryInterface;
+
+/**
+ * Class SqsFactory
+ */
+class SqsFactory implements FactoryInterface
+{
+    protected $connections = array();
+    protected $messageProviders = array();
+    protected $messagePublishers = array();
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addConnection($name, array $connection)
+    {
+        $this->connections[$name] = $connection;
+    }
+
+    /**
+     * getMessageProvider.
+     *
+     * @param string $name       The name of the queue where the MessageProviderInterface will found messages
+     * @param string $connection The name of the connection to use
+     *
+     * @return MessageProviderInterface
+     */
+    public function getMessageProvider($name, $connection)
+    {
+        if (!isset($this->messageProviders[$connection][$name])) {
+            if (!isset($this->messageProviders[$connection])) {
+                $this->messageProviders[$connection] = array();
+            }
+
+            $channel = $this->getChannel($connection);
+
+            $this->messageProviders[$connection][$name] = new SqsMessageProvider($channel, $this->connections[$connection]['vhost'] . $name);
+        }
+
+        return $this->messageProviders[$connection][$name];
+    }
+
+    /**
+     * getMessagePublisher.
+     *
+     * @param string $name       The name of the exchange where the MessagePublisher will publish
+     * @param string $connection The name of the connection to use
+     *
+     * @return MessagePublisherInterface
+     */
+    public function getMessagePublisher($name, $connection)
+    {
+        throw new \Exception('Implement method getMessagePublisher');
+    }
+
+    /**
+     * getChannel.
+     *
+     * @param string $connection
+     *
+     * @return SqsClient
+     */
+    protected function getChannel($connection)
+    {
+        return SqsClient::factory([
+            'key' => $this->connections[$connection]['login'],
+            'secret' => $this->connections[$connection]['password'],
+            'region' => $this->connections[$connection]['host'],
+        ]);
+    }
+}

--- a/Broker/SqsFactory.php
+++ b/Broker/SqsFactory.php
@@ -13,9 +13,9 @@ use Swarrot\SwarrotBundle\Broker\FactoryInterface;
  */
 class SqsFactory implements FactoryInterface
 {
-    protected $connections = array();
-    protected $messageProviders = array();
-    protected $messagePublishers = array();
+    private $connections = array();
+    private $messageProviders = array();
+    private $messagePublishers = array();
 
     /**
      * {@inheritDoc}
@@ -26,8 +26,6 @@ class SqsFactory implements FactoryInterface
     }
 
     /**
-     * getMessageProvider.
-     *
      * @param string $name       The name of the queue where the MessageProviderInterface will found messages
      * @param string $connection The name of the connection to use
      *
@@ -68,8 +66,16 @@ class SqsFactory implements FactoryInterface
      *
      * @return SqsClient
      */
-    protected function getChannel($connection)
+    private function getChannel($connection)
     {
+        if (!isset($this->connections[$connection])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Unknown connection "%s". Available: [%s]',
+                $connection,
+                implode(', ', array_keys($this->connections))
+            ));
+        }
+
         return SqsClient::factory([
             'key' => $this->connections[$connection]['login'],
             'secret' => $this->connections[$connection]['password'],

--- a/Broker/SqsFactory.php
+++ b/Broker/SqsFactory.php
@@ -40,7 +40,7 @@ class SqsFactory implements FactoryInterface
 
             $channel = $this->getChannel($connection);
 
-            $this->messageProviders[$connection][$name] = new SqsMessageProvider($channel, $this->connections[$connection]['vhost'] . $name);
+            $this->messageProviders[$connection][$name] = new SqsMessageProvider($channel, $this->connections[$connection]['host'] . $name);
         }
 
         return $this->messageProviders[$connection][$name];
@@ -79,7 +79,7 @@ class SqsFactory implements FactoryInterface
         return SqsClient::factory([
             'key' => $this->connections[$connection]['login'],
             'secret' => $this->connections[$connection]['password'],
-            'region' => $this->connections[$connection]['host'],
+            'region' => $this->connections[$connection]['region'],
         ]);
     }
 }

--- a/Broker/SqsFactory.php
+++ b/Broker/SqsFactory.php
@@ -56,7 +56,7 @@ class SqsFactory implements FactoryInterface
      */
     public function getMessagePublisher($name, $connection)
     {
-        throw new \Exception('Implement method getMessagePublisher');
+        throw new \BadMethodCallException('Publishing messages to SQS is not implemented yet');
     }
 
     /**

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -119,6 +119,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('login')->defaultValue('guest')->cannotBeEmpty()->end()
                             ->scalarNode('password')->defaultValue('guest')->end()
                             ->scalarNode('vhost')->defaultValue('/')->cannotBeEmpty()->end()
+                            ->scalarNode('region')->defaultNull()->end()
                             ->booleanNode('ssl')->defaultValue(false)->end()
                             ->arrayNode('ssl_options')
                                 ->children()
@@ -196,6 +197,22 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->isRequired()->end()
                 ->end()
                 ->booleanNode('enable_collector')->defaultValue($this->debug)->end()
+            ->end()
+            ->validate()
+                ->ifTrue(function($v) {
+                    if ('sqs' !== $v['provider']) {
+                        return false;
+                    }
+
+                    foreach ($v['connections'] as $connection) {
+                        if (null === $connection['region']) {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                })
+                ->thenInvalid('If you are using the sqs provider, you need to complete the region parameter')
             ->end()
         ;
 

--- a/Resources/config/swarrot.xml
+++ b/Resources/config/swarrot.xml
@@ -5,6 +5,7 @@
     <parameters>
         <parameter key="swarrot.factory.pecl.class">Swarrot\SwarrotBundle\Broker\PeclFactory</parameter>
         <parameter key="swarrot.factory.amqp_lib.class">Swarrot\SwarrotBundle\Broker\AmqpLibFactory</parameter>
+        <parameter key="swarrot.factory.sqs.class">Swarrot\SwarrotBundle\Broker\SqsFactory</parameter>
         <parameter key="swarrot.command.base.class">Swarrot\SwarrotBundle\Command\SwarrotCommand</parameter>
         <parameter key="swarrot.publisher.class">Swarrot\SwarrotBundle\Broker\Publisher</parameter>
     </parameters>
@@ -16,6 +17,9 @@
         </service>
         <service id="swarrot.factory.amqp_lib" class="%swarrot.factory.amqp_lib.class%">
             <tag name="swarrot.provider_factory" alias="amqp_lib"/>
+        </service>
+        <service id="swarrot.factory.sqs" class="%swarrot.factory.sqs.class%">
+            <tag name="swarrot.provider_factory" alias="sqs"/>
         </service>
 
         <service id="swarrot.command.base" class="%swarrot.command.base.class%" abstract="true">

--- a/Tests/Broker/SqsFactoryTest.php
+++ b/Tests/Broker/SqsFactoryTest.php
@@ -3,7 +3,6 @@
 namespace Swarrot\SwarrotBundle\Tests\Broker;
 
 use Swarrot\SwarrotBundle\Broker\SqsFactory;
-use Phake;
 use Swarrot\Broker\MessageProvider\MessageProviderInterface;
 use Swarrot\SwarrotBundle\Broker\FactoryInterface;
 
@@ -20,7 +19,7 @@ class SqsFactoryTest extends \PHPUnit_Framework_TestCase
     /**
      * Set up the test
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->factory = new SqsFactory();
     }

--- a/Tests/Broker/SqsFactoryTest.php
+++ b/Tests/Broker/SqsFactoryTest.php
@@ -40,8 +40,8 @@ class SqsFactoryTest extends \PHPUnit_Framework_TestCase
         $this->factory->addConnection('sqs', [
             'login' => 'key',
             'password' => 'secret',
-            'host' => 'eu-west-1',
-            'vhost' => 'localhost/',
+            'region' => 'eu-west-1',
+            'host' => 'localhost/',
         ]);
 
         $messageProvider = $this->factory->getMessageProvider('workers-test', 'sqs');

--- a/Tests/Broker/SqsFactoryTest.php
+++ b/Tests/Broker/SqsFactoryTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Swarrot\SwarrotBundle\Tests\Broker;
+
+use Swarrot\SwarrotBundle\Broker\SqsFactory;
+use Phake;
+use Swarrot\Broker\MessageProvider\MessageProviderInterface;
+use Swarrot\SwarrotBundle\Broker\FactoryInterface;
+
+/**
+ * Class SqsFactoryTest
+ */
+class SqsFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var SqsFactory
+     */
+    protected $factory;
+
+    /**
+     * Set up the test
+     */
+    public function setUp()
+    {
+        $this->factory = new SqsFactory();
+    }
+
+    /**
+     * Test instance
+     */
+    public function testInstance()
+    {
+        $this->assertInstanceOf(FactoryInterface::CLASS, $this->factory);
+    }
+
+    /**
+     * Test get message provider
+     */
+    public function testGetMessageProvider()
+    {
+        $this->factory->addConnection('sqs', [
+            'login' => 'key',
+            'password' => 'secret',
+            'host' => 'eu-west-1',
+            'vhost' => 'localhost/',
+        ]);
+
+        $messageProvider = $this->factory->getMessageProvider('workers-test', 'sqs');
+
+        $this->assertInstanceOf(MessageProviderInterface::CLASS, $messageProvider);
+        $this->assertSame('localhost/workers-test', $messageProvider->getQueueName());
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,13 @@
         "phpunit/phpunit": "~4.5",
         "symfony/phpunit-bridge": "~2.8|~3.0",
         "doctrine/dbal": "~2.2",
-        "doctrine/Common": "~2.2"
+        "doctrine/Common": "~2.2",
+        "aws/aws-sdk-php": "2.*",
+        "phake/phake": "^2.3"
     },
     "suggest": {
-        "php-amqplib/php-amqplib": "Required if using amqp_lib"
+        "php-amqplib/php-amqplib": "Required if using amqp_lib",
+        "aws/aws-sdk-php": "Required to use the aws sqs provider"
     },
     "config": {
         "bin-dir": "bin"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "swarrot/swarrot": "^2.1.1",
+        "swarrot/swarrot": "dev-master",
         "psr/log": "~1.0",
         "symfony/framework-bundle": "~2.4|~3.0",
         "symfony/console": "~2.4|~3.0"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "swarrot/swarrot": "dev-master",
+        "swarrot/swarrot": "^2.1.1",
         "psr/log": "~1.0",
         "symfony/framework-bundle": "~2.4|~3.0",
         "symfony/console": "~2.4|~3.0"
@@ -21,8 +21,7 @@
         "symfony/phpunit-bridge": "~2.8|~3.0",
         "doctrine/dbal": "~2.2",
         "doctrine/Common": "~2.2",
-        "aws/aws-sdk-php": "2.*",
-        "phake/phake": "^2.3"
+        "aws/aws-sdk-php": "2.*"
     },
     "suggest": {
         "php-amqplib/php-amqplib": "Required if using amqp_lib",


### PR DESCRIPTION
In the configuration, the provider can be set to `sqs`.

For the other keys : 
- `region` is used to determine the aws region for the sqs instance
- `host` determine the access url for the sqs instance

This pr is linked to https://github.com/swarrot/swarrot/pull/134
