### PR TITLE
RPC responses have to be publish on (AMQP default) exchange

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ before_script:
   - sh -c "sudo ./Tests/bin/prepare_rabbit.sh"
 
 # Due to not yet solved issue with phpdocumentor & php 5.5 https://github.com/phpDocumentor/ReflectionDocBlock/issues/80
-script: vendor/phpunit/phpunit/phpunit
+script: bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,15 @@ before_install:
   - composer self-update
   - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
   - if [[ ! $skip && ! $PHP = hhvm* ]]; then phpenv config-rm xdebug.ini; fi
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/framework-bundle:"$SYMFONY_VERSION"; fi
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/console:"$SYMFONY_VERSION"; fi
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --no-update symfony/framework-bundle:"$SYMFONY_VERSION" symfony/console:"$SYMFONY_VERSION"; fi
+
+install:
+  - composer update $COMPOSER_FLAGS
 
 before_script:
   - sh -c 'if [ "$LIBRABBITMQ_VERSION" != "" ]; then ./Tests/bin/install_librabbitmq.sh; fi;'
   - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "extension=amqp.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi;'
   - sh -c "sudo ./Tests/bin/prepare_rabbit.sh"
 
-install:
-  - composer update $COMPOSER_FLAGS
+# Due to not yet solved issue with phpdocumentor & php 5.5 https://github.com/phpDocumentor/ReflectionDocBlock/issues/80
+script: vendor/phpunit/phpunit/phpunit

--- a/Processor/RPC/RpcServerProcessorConfigurator.php
+++ b/Processor/RPC/RpcServerProcessorConfigurator.php
@@ -32,9 +32,11 @@ class RpcServerProcessorConfigurator implements ProcessorConfiguratorInterface
      */
     public function getProcessorArguments(array $options)
     {
+        $exchange = $this->getExtra('rpc_exchange', '');
+
         return [
             'Swarrot\Processor\RPC\RpcServerProcessor',
-            $this->factory->getMessagePublisher('', $options['connection']),
+            $this->factory->getMessagePublisher($exchange, $options['connection']),
             $this->logger,
         ];
     }

--- a/Processor/RPC/RpcServerProcessorConfigurator.php
+++ b/Processor/RPC/RpcServerProcessorConfigurator.php
@@ -32,11 +32,9 @@ class RpcServerProcessorConfigurator implements ProcessorConfiguratorInterface
      */
     public function getProcessorArguments(array $options)
     {
-        $exchange = $this->getExtra('rpc_exchange', 'retry');
-
         return [
             'Swarrot\Processor\RPC\RpcServerProcessor',
-            $this->factory->getMessagePublisher($exchange, $options['connection']),
+            $this->factory->getMessagePublisher('', $options['connection']),
             $this->logger,
         ];
     }
@@ -54,6 +52,6 @@ class RpcServerProcessorConfigurator implements ProcessorConfiguratorInterface
      */
     public function resolveOptions(InputInterface $input)
     {
-        return $this->getExtras();
+        return [];
     }
 }

--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ swarrot:
                  #       new_relic_transaction_name: ~
 
                  # - configurator: swarrot.processor.rpc_server
-                 #   extras:
-                 #       rpc_exchange: rpc
                  # - configurator: swarrot.processor.rpc_client
                  #   extras:
                  #       rpc_client_correlation_id: ~

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ swarrot:
                  #       new_relic_transaction_name: ~
 
                  # - configurator: swarrot.processor.rpc_server
+                 #   extras:
+                 #       # Exchange on which rpc response will be published with `reply_to` as routing_key. 
+                 #       # If not configured will publish on default exchange where routing_key is used to define receiving queue.
+                 #       rpc_exchange: rpc 
                  # - configurator: swarrot.processor.rpc_client
                  #   extras:
                  #       rpc_client_correlation_id: ~

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ swarrot:
                  #   extras:
                  #       # Exchange on which rpc response will be published with `reply_to` as routing_key. 
                  #       # If not configured will publish on default exchange where routing_key is used to define receiving queue.
-                 #       rpc_exchange: rpc 
+                 #       rpc_exchange: ~ 
                  # - configurator: swarrot.processor.rpc_client
                  #   extras:
                  #       rpc_client_correlation_id: ~

--- a/Tests/Processor/RPC/RpcServerProcessorConfiguratorTest.php
+++ b/Tests/Processor/RPC/RpcServerProcessorConfiguratorTest.php
@@ -2,50 +2,77 @@
 
 namespace Swarrot\SwarrotBundle\Tests\Processor\RPC;
 
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\LoggerInterface;
+use Swarrot\SwarrotBundle\Broker\FactoryInterface;
 use Swarrot\SwarrotBundle\Processor\RPC\RpcServerProcessorConfigurator;
 use Swarrot\SwarrotBundle\Tests\Processor\ProcessorConfiguratorTestCase;
 
 class RpcServerProcessorConfiguratorTest extends ProcessorConfiguratorTestCase
 {
+    /**
+     * @var FactoryInterface|ObjectProphecy
+     */
+    private $factory;
+
+    /**
+     * @var LoggerInterface|ObjectProphecy
+     */
+    private $logger;
+
+    /**
+     * @var RpcServerProcessorConfigurator
+     */
+    private $configurator;
+
+    public function setUp()
+    {
+        $this->factory = $this->prophesize('Swarrot\SwarrotBundle\Broker\FactoryInterface');
+        $this->logger = $this->prophesize('Psr\Log\LoggerInterface');
+
+        $this->configurator = new RpcServerProcessorConfigurator(
+            $this->factory->reveal(),
+            $this->logger->reveal()
+        );
+    }
+
     public function test_it_is_initializable()
     {
-        $configurator = new RpcServerProcessorConfigurator(
-            $this->prophesize('Swarrot\SwarrotBundle\Broker\FactoryInterface')->reveal(),
-            $this->prophesize('Psr\Log\LoggerInterface')->reveal()
-        );
-        $this->assertInstanceOf('Swarrot\SwarrotBundle\Processor\RPC\RpcServerProcessorConfigurator', $configurator);
+        $this->assertInstanceOf('Swarrot\SwarrotBundle\Processor\RPC\RpcServerProcessorConfigurator', $this->configurator);
     }
 
     public function test_it_resolves_no_options()
     {
-        $configurator = new RpcServerProcessorConfigurator(
-            $this->prophesize('Swarrot\SwarrotBundle\Broker\FactoryInterface')->reveal(),
-            $this->prophesize('Psr\Log\LoggerInterface')->reveal()
-        );
-        $configurator->setExtras(['rpc_exchange' => 'exchange']);
-        $input = $this->getUserInput([], $configurator);
+        $this->configurator->setExtras(['rpc_exchange' => 'exchange']);
+        $input = $this->getUserInput([], $this->configurator);
 
-        $this->assertSame([], $configurator->resolveOptions($input));
+        $this->assertSame([], $this->configurator->resolveOptions($input));
     }
 
-    public function test_it_can_returns_a_valid_processor()
+    public function test_it_can_returns_a_valid_processor_with_default_empty_exchange()
     {
-        $stubLogger = $this->prophesize('Psr\Log\LoggerInterface')->reveal();
-        $stubMessagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface')->reveal();
-        $mockFactory = $this->prophesize('Swarrot\SwarrotBundle\Broker\FactoryInterface');
-        $dummyQueue = uniqid();
-        $dummyConnection = uniqid();
+        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
 
-        $mockFactory->getMessagePublisher('', $dummyConnection)
+        $this->factory->getMessagePublisher('', 'foo:bar@bar.com:5672')
             ->shouldBeCalled()
-            ->willReturn($stubMessagePublisher);
+            ->willReturn($messagePublisher->reveal());
 
-        $configurator = new RpcServerProcessorConfigurator(
-            $mockFactory->reveal(),
-            $stubLogger
-        );
+        $processor = $this->createProcessor($this->configurator, ['queue' => 'queue.rpc', 'connection' => 'foo:bar@bar.com:5672']);
 
-        $processor = $this->createProcessor($configurator, ['queue' => $dummyQueue, 'connection' => $dummyConnection]);
+        $this->assertInstanceOf('Swarrot\Processor\RPC\RpcServerProcessor', $processor);
+    }
+
+    public function test_it_can_returns_a_valid_processor_with_configurable_exchange()
+    {
+        $messagePublisher = $this->prophesize('Swarrot\Broker\MessagePublisher\MessagePublisherInterface');
+
+        $this->configurator->setExtras(['rpc_exchange' => 'exchange.rpc']);
+
+        $this->factory->getMessagePublisher('exchange.rpc', 'foo:bar@bar.com:5672')
+            ->shouldBeCalled()
+            ->willReturn($messagePublisher->reveal());
+
+        $processor = $this->createProcessor($this->configurator, ['queue' => 'queue.rpc', 'connection' => 'foo:bar@bar.com:5672']);
 
         $this->assertInstanceOf('Swarrot\Processor\RPC\RpcServerProcessor', $processor);
     }

--- a/Tests/Processor/RPC/RpcServerProcessorConfiguratorTest.php
+++ b/Tests/Processor/RPC/RpcServerProcessorConfiguratorTest.php
@@ -16,13 +16,13 @@ class RpcServerProcessorConfiguratorTest extends ProcessorConfiguratorTestCase
         $this->assertInstanceOf('Swarrot\SwarrotBundle\Processor\RPC\RpcServerProcessorConfigurator', $configurator);
     }
 
-    public function test_it_resolves_options()
+    public function test_it_resolves_no_options()
     {
         $configurator = new RpcServerProcessorConfigurator(
             $this->prophesize('Swarrot\SwarrotBundle\Broker\FactoryInterface')->reveal(),
             $this->prophesize('Psr\Log\LoggerInterface')->reveal()
         );
-        $configurator->setExtras([]);
+        $configurator->setExtras(['rpc_exchange' => 'exchange']);
         $input = $this->getUserInput([], $configurator);
 
         $this->assertSame([], $configurator->resolveOptions($input));
@@ -36,7 +36,7 @@ class RpcServerProcessorConfiguratorTest extends ProcessorConfiguratorTestCase
         $dummyQueue = uniqid();
         $dummyConnection = uniqid();
 
-        $mockFactory->getMessagePublisher('retry', $dummyConnection)
+        $mockFactory->getMessagePublisher('', $dummyConnection)
             ->shouldBeCalled()
             ->willReturn($stubMessagePublisher);
 

--- a/Tests/fixtures/default_configuration.yml
+++ b/Tests/fixtures/default_configuration.yml
@@ -43,7 +43,5 @@ swarrot:
             routing_key:          null
             extras:               []
 
-        # Prototype
-        name:                 ~
     enable_collector:     true
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "swarrot/swarrot": "^2.1.1",
         "psr/log": "~1.0",
         "symfony/framework-bundle": "~2.4|~3.0",
-        "symfony/console": "~2.4|~3.0"
+        "symfony/console": "~2.4|~3.0",
+        "symfony/yaml": ">2.0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "psr/log": "~1.0",
         "symfony/framework-bundle": "~2.4|~3.0",
         "symfony/console": "~2.4|~3.0",
-        "symfony/yaml": ">2.0.4"
+        "symfony/yaml": "~2.4|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",


### PR DESCRIPTION
While trying to use the `RpcServerProcessor` I run into the following issue

<img width="688" alt="capture d ecran 2016-12-29 a 20 19 14" src="https://cloud.githubusercontent.com/assets/1516110/21552758/1cf5ebf6-ce04-11e6-88b8-b61e280d9e4c.png">

Returning `[]` instead of `$this->getExtras();` in
[RpcServerProcessorConfigurator](https://github.com/swarrot/SwarrotBundle/blob/master/Processor/RPC/RpcServerProcessorConfigurator.php)  fixed the issue
```php
namespace Swarrot\SwarrotBundle\Processor\RPC;

class RpcServerProcessorConfigurator implements ProcessorConfiguratorInterface
{
    public function resolveOptions(InputInterface $input)
    {
        return [];
    }
}
```

[RabbitMQ example of RPC pattern](https://www.rabbitmq.com/tutorials/tutorial-six-python.html) 
![image](https://cloud.githubusercontent.com/assets/1516110/21552484/1f509970-ce02-11e6-949e-ad67510c76b7.png)

[AMQP 0.9.1 RFC](https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf) define that "To publish to a reply queue a producer sends a message to the default exchange"
<img width="686" alt="capture d ecran 2016-12-29 a 20 35 58" src="https://cloud.githubusercontent.com/assets/1516110/21553613/84b80c74-ce09-11e6-83b5-97cdeb9be331.png">
<img width="660" alt="capture d ecran 2016-12-30 a 11 20 04" src="https://cloud.githubusercontent.com/assets/1516110/21563375/1196c3c4-ce82-11e6-8db8-05e137f37ec6.png">

So RPC exchange should never be defined by configuration, it should always be empty.
