### PR TITLE
Switch getChannel to public

### DIFF
--- a/Broker/AmqpLibFactory.php
+++ b/Broker/AmqpLibFactory.php
@@ -60,13 +60,13 @@ class AmqpLibFactory implements FactoryInterface
     }
 
     /**
-     * getChannel.
+     * Return the AMQPChannel of the given connection.
      *
      * @param string $connection
      *
      * @return AMQPChannel
      */
-    protected function getChannel($connection)
+    public function getChannel($connection)
     {
         if (isset($this->channels[$connection])) {
             return $this->channels[$connection];


### PR DESCRIPTION
This will fix https://github.com/swarrot/SwarrotBundle/issues/97

But more globally it'll allow anyone to retrieve the channel of a RabbitMQ connection using the `swarrot.factory.default` service (if you defined the provider as `amqp_lib`) and then do whatever you want with it (like retrieve a message, etc.).

For example you can retrieve one message (without ack'ing it) to retrieve the total messages in a queue:

```php
$message = $this
    ->get('swarrot.factory.default')
    ->getChannel('rabbitmq') // returns a PhpAmqpLib\Channel\AMQPChannel
    ->basic_get('queue_name'); // returns a PhpAmqpLib\Message\AMQPMessage

var_dump($message->delivery_info['message_count']);
```

