### PR TITLE
Fix extras consumers option configuration type

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -151,7 +151,7 @@ class Configuration implements ConfigurationInterface
                                         ->scalarNode('configurator')->isRequired()->end()
                                         ->scalarNode('first_arg_class')->defaultValue(null)->end()
                                         ->arrayNode('extras')
-                                            ->prototype('scalar')->end()
+                                            ->prototype('variable')->end()
                                         ->end()
                                     ->end()
                                 ->end()

--- a/Tests/fixtures/default_configuration.php
+++ b/Tests/fixtures/default_configuration.php
@@ -28,9 +28,14 @@ return [
             'queue' => null,
             'extras' => [],
             'middleware_stack' => [
-                'name' => [
+                [
                     'configurator' => null,
-                    'extras' => [],
+                    'extras' => [
+                        'foo' => 'bar',
+                        'baz' => [
+                            'bar'
+                        ]
+                    ],
                     'first_arg_class' => null,
                 ]
             ],

--- a/Tests/fixtures/default_configuration.yml
+++ b/Tests/fixtures/default_configuration.yml
@@ -30,10 +30,11 @@ swarrot:
             middleware_stack:
 
                 # Prototype
-                name:
-                    configurator:    ~
-                    extras:          []
-
+                - configurator:    ~
+                  extras:
+                      foo: bar
+                      baz:
+                          - bar
     messages_types:
 
         # Prototype


### PR DESCRIPTION
This PR allows to use an array as `extras` option value for a middleware. For the moment, only scalars values are allowed, but the doc example contains an array for the `swarrot.processor.signal_handler` processor.

```yaml
swarrot:
    consumers:
        my_consumer:
            processor: my_consumer.processor.service
            middleware_stack:
                 - configurator: swarrot.processor.signal_handler
                   extras:
                       signal_handler_signals: # Not ok for now
                           - SIGTERM
                           - SIGINT
                           - SIGQUIT
                 - configurator: swarrot.processor.max_messages
                   extras:
                       max_messages: 100 # Already ok
```