### PR TITLE
Support `retry_log_levels_map` and `retry_fail_log_levels_map` configuration in extras

### DIFF
--- a/Processor/Retry/RetryProcessorConfigurator.php
+++ b/Processor/Retry/RetryProcessorConfigurator.php
@@ -76,6 +76,8 @@ class RetryProcessorConfigurator implements ProcessorConfiguratorInterface
         return [
             'retry_key_pattern' => str_replace('%queue%', $input->getArgument('queue'), $key),
             'retry_attempts' => (int) $input->getOption('retry-attempts'),
+            'retry_log_levels_map' => $this->getExtra('retry_log_levels_map', []),
+            'retry_fail_log_levels_map' => $this->getExtra('retry_fail_log_levels_map', []),
         ];
     }
 }

--- a/Tests/Processor/Retry/RetryProcessorConfiguratorTest.php
+++ b/Tests/Processor/Retry/RetryProcessorConfiguratorTest.php
@@ -24,11 +24,23 @@ class RetryProcessorConfiguratorTest extends ProcessorConfiguratorTestCase
             $this->prophesize('Swarrot\SwarrotBundle\Broker\FactoryInterface')->reveal(),
             $this->prophesize('Psr\Log\LoggerInterface')->reveal()
         );
-        $configurator->setExtras(['retry_routing_key_pattern' => 'my_queue', 'retry_attempts' => 4]);
+        $configurator->setExtras(
+            [
+                'retry_routing_key_pattern' => 'my_queue',
+                'retry_attempts' => 4,
+                'retry_log_levels_map' => array('\Exception' => 'error'),
+                'retry_fail_log_levels_map' => array('\Exception' => 'error'),
+            ]
+        );
         $input = $this->getUserInput([], $configurator);
 
         $this->assertSame(
-            ['retry_key_pattern' => 'my_queue', 'retry_attempts' => 4],
+            [
+                'retry_key_pattern' => 'my_queue',
+                'retry_attempts' => 4,
+                'retry_log_levels_map' => ['\Exception' => 'error'],
+                'retry_fail_log_levels_map' => ['\Exception' => 'error'],
+            ],
             $configurator->resolveOptions($input)
         );
     }
@@ -45,7 +57,12 @@ class RetryProcessorConfiguratorTest extends ProcessorConfiguratorTestCase
         $input = $this->getUserInput(['--retry-attempts' => 5], $configurator);
 
         $this->assertSame(
-            ['retry_key_pattern' => 'retry_%attempt%s', 'retry_attempts' => 5],
+            [
+                'retry_key_pattern' => 'retry_%attempt%s',
+                'retry_attempts' => 5,
+                'retry_log_levels_map' => [],
+                'retry_fail_log_levels_map' => [],
+            ],
             $configurator->resolveOptions($input)
         );
     }
@@ -62,7 +79,12 @@ class RetryProcessorConfiguratorTest extends ProcessorConfiguratorTestCase
         $input = $this->getUserInput([], $configurator);
 
         $this->assertSame(
-            ['retry_key_pattern' => 'retry_%attempt%s', 'retry_attempts' => 3],
+            [
+                'retry_key_pattern' => 'retry_%attempt%s',
+                'retry_attempts' => 3,
+                'retry_log_levels_map' => [],
+                'retry_fail_log_levels_map' => [],
+            ],
             $configurator->resolveOptions($input)
         );
     }


### PR DESCRIPTION
Hi there, 

We wanted to use Swarrot RetryProcessor's `retry_fail_log_levels_map` feature but we were unable to setup it using SwarrotBundle.

Here's a proposal patch enabling users to do this :)