### PR TITLE
Explicitly exposes the public services

### DIFF
--- a/DependencyInjection/Compiler/ProviderCompilerPass.php
+++ b/DependencyInjection/Compiler/ProviderCompilerPass.php
@@ -2,6 +2,7 @@
 
 namespace Swarrot\SwarrotBundle\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -52,7 +53,7 @@ class ProviderCompilerPass implements CompilerPassInterface
             ]);
         }
 
-        $container->setAlias('swarrot.factory.default', $id);
+        $container->setAlias('swarrot.factory.default', new Alias($id, true));
         $container->getParameterBag()->remove('swarrot.provider_config');
     }
 }

--- a/DependencyInjection/SwarrotExtension.php
+++ b/DependencyInjection/SwarrotExtension.php
@@ -121,7 +121,9 @@ class SwarrotExtension extends Extension
             ->replaceArgument(2, new Reference($consumerConfig['processor']))
             ->replaceArgument(3, $processorConfigurators)
             ->replaceArgument(4, $consumerConfig['extras'])
-            ->replaceArgument(5, $consumerConfig['queue']);
+            ->replaceArgument(5, $consumerConfig['queue'])
+            ->setPublic(true)
+        ;
 
         return $id;
     }

--- a/Resources/config/swarrot.xml
+++ b/Resources/config/swarrot.xml
@@ -30,7 +30,7 @@
             </call>
         </service>
 
-        <service id="swarrot.publisher" class="%swarrot.publisher.class%">
+        <service id="swarrot.publisher" class="%swarrot.publisher.class%" public="true">
             <argument type="service" id="swarrot.factory.default" />
             <argument type="service" id="event_dispatcher" />
             <argument>%swarrot.messages_types%</argument>

--- a/Tests/DependencyInjection/Compiler/ProviderCompilerPassTest.php
+++ b/Tests/DependencyInjection/Compiler/ProviderCompilerPassTest.php
@@ -3,6 +3,7 @@
 namespace Swarrot\SwarrotBundle\Tests\DependencyInjection\Compiler;
 
 use Swarrot\SwarrotBundle\DependencyInjection\Compiler\ProviderCompilerPass;
+use Symfony\Component\DependencyInjection\Alias;
 
 class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
 {
@@ -299,7 +300,7 @@ class ProviderCompilerPassTest extends \PHPUnit_Framework_TestCase
         $container
             ->expects($this->once())
             ->method('setAlias')
-            ->with('swarrot.factory.default', 'foo')
+            ->with('swarrot.factory.default', new Alias('foo', true))
         ;
 
         $compiler = new ProviderCompilerPass();

--- a/Tests/DependencyInjection/SwarrotExtensionTest.php
+++ b/Tests/DependencyInjection/SwarrotExtensionTest.php
@@ -61,9 +61,11 @@ class SwarrotExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('testing', $commands);
         $this->assertSame('swarrot.command.generated.testing', $commands['testing']);
 
-        $configurators = $container->getDefinition('swarrot.command.generated.testing')->getArgument(3);
+        $testingCommandDefinition = $container->getDefinition('swarrot.command.generated.testing');
+        $configurators = $testingCommandDefinition->getArgument(3);
         $this->assertInternalType('array', $configurators);
         $this->assertCount(1, $configurators);
+        $this->assertTrue($testingCommandDefinition->isPublic());
 
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $configurators[0]);
         $configuratorDefinition = $container->getDefinition((string) $configurators[0]);

--- a/Tests/DependencyInjection/SwarrotExtensionTest.php
+++ b/Tests/DependencyInjection/SwarrotExtensionTest.php
@@ -167,6 +167,14 @@ class SwarrotExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('my_awesome_logger', (string) $alias);
     }
 
+    public function test_it_exposes_the_publisher_service()
+    {
+        $container = $this->createContainer(false);
+        $this->loadConfig($container);
+
+        $this->assertTrue($container->getDefinition('swarrot.publisher')->isPublic());
+    }
+
     private function assertHasService(ContainerBuilder $container, $id)
     {
         $this->assertTrue(


### PR DESCRIPTION
Symfony 4 will have private services by default. This PR explicitly exposes the `swarrot.publisher` service.