### PR TITLE
Associative array with serviceId as key for Command::processorConfigurators

### DIFF
--- a/DependencyInjection/SwarrotExtension.php
+++ b/DependencyInjection/SwarrotExtension.php
@@ -102,9 +102,8 @@ class SwarrotExtension extends Extension
     {
         $processorConfigurators = [];
         foreach ($consumerConfig['middleware_stack'] as $middlewareStackConfig) {
-            $processorConfigurators[] = new Reference(
-                $this->buildCommandProcessorConfigurator($container, $name, $middlewareStackConfig)
-            );
+            $configuratorId = $this->buildCommandProcessorConfigurator($container, $name, $middlewareStackConfig);
+            $processorConfigurators[$configuratorId] = new Reference($configuratorId);
         }
 
         $id = 'swarrot.command.generated.'.$name;

--- a/Tests/DependencyInjection/SwarrotExtensionTest.php
+++ b/Tests/DependencyInjection/SwarrotExtensionTest.php
@@ -67,8 +67,8 @@ class SwarrotExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $configurators);
         $this->assertTrue($testingCommandDefinition->isPublic());
 
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $configurators[0]);
-        $configuratorDefinition = $container->getDefinition((string) $configurators[0]);
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', array_values($configurators)[0]);
+        $configuratorDefinition = $container->getDefinition((string) array_values($configurators)[0]);
 
         $this->assertCount(1, $configuratorDefinition->getMethodCalls());
         $method = $configuratorDefinition->getMethodCalls()[0];
@@ -101,8 +101,8 @@ class SwarrotExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $configurators);
         $this->assertCount(1, $configurators);
 
-        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $configurators[0]);
-        $configuratorDefinition = $container->getDefinition((string) $configurators[0]);
+        $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', array_values($configurators)[0]);
+        $configuratorDefinition = $container->getDefinition((string) array_values($configurators)[0]);
         $this->assertEquals('AppBundle\\MyAckProcessor', $configuratorDefinition->getArgument(0));
     }
 


### PR DESCRIPTION
Hi @odolbeau 

In my project, each message needs to be processed in an isolated SymfonyKernel, to archive that I need list of Middleware service IDs, so I made some code changes, can you please help to review.

Thank you for your awesome work!