### PR TITLE
Implemented `reset` in data collector

### DIFF
--- a/DataCollector/SwarrotDataCollector.php
+++ b/DataCollector/SwarrotDataCollector.php
@@ -59,4 +59,9 @@ class SwarrotDataCollector extends DataCollector
     {
         return 'swarrot';
     }
+
+    public function reset()
+    {
+        $this->data = [];
+    }
 }


### PR DESCRIPTION
Otherwise it will trigger a deprecation in Symfony 3.4 and an error in 4.0

`User Deprecated: Implementing "Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface" without the "reset()" method is deprecated since version 3.4 and will be unsupported in 4.0 for class "Swarrot\SwarrotBundle\DataCollector\SwarrotDataCollector".`