### PR TITLE
Cast broker port configuration variable to int

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -116,7 +116,15 @@ class Configuration implements ConfigurationInterface
                         ->children()
                             ->scalarNode('url')->info('A URL with connection information; any parameter value parsed from this string will override explicitly set parameters')->end()
                             ->scalarNode('host')->defaultValue('127.0.0.1')->end()
-                            ->integerNode('port')->defaultValue(5672)->end()
+                            ->integerNode('port')
+                                ->beforeNormalization()
+                                    ->ifString()
+                                    ->then(function(string $port): int {
+                                        return (int) $port;
+                                    })
+                                ->end()
+                                ->defaultValue(5672)
+                            ->end()
                             ->scalarNode('login')->defaultValue('guest')->end()
                             ->scalarNode('password')->defaultValue('guest')->end()
                             ->scalarNode('vhost')->defaultValue('/')->end()


### PR DESCRIPTION
I've the same issue describe in #131 with environment variables, even if I use the `int:` cast with Symfony 3.4.

My configuration looks like : 

```yaml
swarrot:
    connections:
        rabbitmq:
            host: '%env(RABBITMQ_HOST)%'
            port: '%env(int:RABBITMQ_PORT)%'
            login: '%env(RABBITMQ_LOGIN)%'
            password: '%env(RABBITMQ_PASSWORD)%'
            vhost: '/'
```

The DSN solution is not tagged yet. So to keep compatibility with existing configuration, I had a normalisation of the port variable in the dependency configuration.