### PR TITLE
Avoid deprecated notice when using symfony/config > 4.2

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,8 +29,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('swarrot');
+        $treeBuilder = new TreeBuilder('swarrot');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('swarrot');
+        }
 
         $knownProcessors = $this->knownProcessors;
 


### PR DESCRIPTION
See: https://github.com/symfony/symfony/blob/master/UPGRADE-4.2.md#config