### PR TITLE
Updated declaration of SwarrotDataCollector::collect() to match with …

### DIFF
--- a/DataCollector/SwarrotDataCollector.php
+++ b/DataCollector/SwarrotDataCollector.php
@@ -12,7 +12,7 @@ class SwarrotDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, \Exception $exception = null)
+    public function collect(Request $request, Response $response, \Throwable $exception = null)
     {
     }
 


### PR DESCRIPTION
On Symfony 5.0.1, the DataCollectorInterfac::collect() now uses the \Throwable type in the signature, which throws an incompatible error. This patch fixes that.