### PR TITLE
Fixed symfony/http-kernel dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/config": "^3.4|^4.2|^5.0",
         "symfony/console": "^3.4|^4.2|^5.0",
         "symfony/dependency-injection": "^3.4|^4.2|^5.0",
-        "symfony/http-kernel": "^3.4|^4.2|^5.0",
+        "symfony/http-kernel": "^4.2|^5.0",
         "symfony/yaml": "^3.4|^4.2|^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
Since https://github.com/swarrot/SwarrotBundle/pull/169 the bundle is no more compatible with `symfony/http-kernel` version `^3.4`.