### PR TITLE
Use tag to register commands

### DIFF
--- a/DependencyInjection/SwarrotExtension.php
+++ b/DependencyInjection/SwarrotExtension.php
@@ -99,6 +99,9 @@ class SwarrotExtension extends Extension
             ->replaceArgument(5, $consumerConfig['extras'])
             ->replaceArgument(6, $consumerConfig['queue'])
             ->replaceArgument(7, $consumerConfig['command_aliases'])
+            ->addTag('console.command', [
+                'command' => 'swarrot:consume:'.$name,
+            ])
         ;
 
         return $id;

--- a/SwarrotBundle.php
+++ b/SwarrotBundle.php
@@ -3,7 +3,6 @@
 namespace Swarrot\SwarrotBundle;
 
 use Swarrot\SwarrotBundle\DependencyInjection\Compiler\ProviderCompilerPass;
-use Symfony\Component\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -14,15 +13,5 @@ class SwarrotBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new ProviderCompilerPass());
-    }
-
-    public function registerCommands(Application $application)
-    {
-        $container = $application->getKernel()->getContainer();
-
-        $commands = $container->getParameter('swarrot.commands');
-        foreach ($commands as $command) {
-            $application->add($container->get($command));
-        }
     }
 }


### PR DESCRIPTION
Use tag instead of `registerCommands`.

Fix #194 