### PR TITLE
Use hash for definition ID generation instead of uniqid

### DIFF
--- a/DependencyInjection/SwarrotExtension.php
+++ b/DependencyInjection/SwarrotExtension.php
@@ -102,7 +102,8 @@ class SwarrotExtension extends Extension
 
     private function buildCommandProcessorConfigurator(ContainerBuilder $container, string $commandName, array $middlewareStackConfig): string
     {
-        $id = 'swarrot_extra.command.generated.'.$commandName.'.'.uniqid();
+        $hash = hash('md5', $commandName.serialize($middlewareStackConfig));
+        $id = 'swarrot_extra.command.generated.'.$commandName.'.'.$hash;
 
         $definition = $container->setDefinition($id, new ChildDefinition($middlewareStackConfig['configurator']));
         $definition->addMethodCall('setExtras', [$middlewareStackConfig['extras']]);


### PR DESCRIPTION
Hey,
to avoid excessive cache generation in dev mode I think it is better to use a hash algorithm instead of uniqid. The [PhpDumper#L311-L313](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php#L311-L313) also generates a hash with filename and content over all cached files so swarrot generates a diff many times. In this situation symfony generates a new cache container on the filesystem every time.

Thx Eric