### PR TITLE
Update processor for doctrine/persistence:^2.0

### DIFF
--- a/Processor/Doctrine/ObjectManagerProcessorConfigurator.php
+++ b/Processor/Doctrine/ObjectManagerProcessorConfigurator.php
@@ -2,7 +2,7 @@
 
 namespace Swarrot\SwarrotBundle\Processor\Doctrine;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Swarrot\SwarrotBundle\Processor\ProcessorConfiguratorEnableAware;
 use Swarrot\SwarrotBundle\Processor\ProcessorConfiguratorExtrasAware;
 use Swarrot\SwarrotBundle\Processor\ProcessorConfiguratorInterface;

--- a/Tests/Processor/Doctrine/ObjectManagerProcessorConfiguratorTest.php
+++ b/Tests/Processor/Doctrine/ObjectManagerProcessorConfiguratorTest.php
@@ -11,7 +11,7 @@ class ObjectManagerProcessorConfiguratorTest extends ProcessorConfiguratorTestCa
     {
         $configurator = new ObjectManagerProcessorConfigurator(
             'Swarrot\Processor\Doctrine\ObjectManagerProcessor',
-            $this->prophesize('Doctrine\Common\Persistence\ManagerRegistry')->reveal()
+            $this->prophesize('Doctrine\Persistence\ManagerRegistry')->reveal()
         );
         $this->assertInstanceOf(
             'Swarrot\SwarrotBundle\Processor\Doctrine\ObjectManagerProcessorConfigurator',
@@ -23,7 +23,7 @@ class ObjectManagerProcessorConfiguratorTest extends ProcessorConfiguratorTestCa
     {
         $configurator = new ObjectManagerProcessorConfigurator(
             'Swarrot\Processor\Doctrine\ObjectManagerProcessor',
-            $this->prophesize('Doctrine\Common\Persistence\ManagerRegistry')->reveal()
+            $this->prophesize('Doctrine\Persistence\ManagerRegistry')->reveal()
         );
         $configurator->setExtras([]);
         $input = $this->getUserInput([], $configurator);
@@ -35,7 +35,7 @@ class ObjectManagerProcessorConfiguratorTest extends ProcessorConfiguratorTestCa
     {
         $configurator = new ObjectManagerProcessorConfigurator(
             'Swarrot\Processor\Doctrine\ObjectManagerProcessor',
-            $this->prophesize('Doctrine\Common\Persistence\ManagerRegistry')->reveal()
+            $this->prophesize('Doctrine\Persistence\ManagerRegistry')->reveal()
         );
         $input = $this->getUserInput(['--no-reset' => true], $configurator);
 
@@ -45,7 +45,7 @@ class ObjectManagerProcessorConfiguratorTest extends ProcessorConfiguratorTestCa
 
     public function test_it_can_returns_a_valid_processor()
     {
-        $dummyConnection = $this->prophesize('Doctrine\Common\Persistence\ManagerRegistry')->reveal();
+        $dummyConnection = $this->prophesize('Doctrine\Persistence\ManagerRegistry')->reveal();
 
         $configurator = new ObjectManagerProcessorConfigurator(
             'Swarrot\Processor\Doctrine\ObjectManagerProcessor',

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,9 @@
             "/Tests/"
         ]
     },
+    "conflict": {
+        "doctrine/persistence": "<1.3"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.0-dev"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "phpunit/phpunit": "^8.4",
         "doctrine/dbal": "^2.2",
-        "doctrine/common": "^2.2",
+        "doctrine/common": "^2.9",
         "php-amqplib/php-amqplib": "^2.9",
         "symfony/phpunit-bridge": "^5.0"
     },


### PR DESCRIPTION
Hello,

We've encounter this error in our app.
```
Symfony\Component\Debug\Exception\FatalThrowableError^ {#2714
  -originalClassName: "TypeError"
  #message: "Argument 2 passed to Swarrot\SwarrotBundle\Processor\Doctrine\ObjectManagerProcessorConfigurator::__construct() must be an instance of Doctrine\Common\Persistence\ManagerRegistry, instance of Doctrine\Bundle\MongoDBBundle\ManagerRegistry given, called in /var/www/MY_APP/var/cache/dev/ContainerE16VOet/getSwarrot_Command_Generated_RequestReportService.php on line 68"
  #code: 0
  #file: "/var/www/MY_APP/vendor/swarrot/swarrot-bundle/Processor/Doctrine/ObjectManagerProcessorConfigurator.php"
  #line: 22
  #severity: E_RECOVERABLE_ERROR
  trace: {
    /var/www/MY_APP/vendor/swarrot/swarrot-bundle/Processor/Doctrine/ObjectManagerProcessorConfigurator.php:22 { …}
    /var/www/MY_APP/var/cache/dev/ContainerE16VOet/getSwarrot_Command_Generated_RequestReportService.php:68 {
      ContainerE16VOet\getSwarrot_Command_Generated_RequestReportService::do($container, $lazyLoad = true)^
      › 
      › $i = new \Swarrot\SwarrotBundle\Processor\Doctrine\ObjectManagerProcessorConfigurator('Swarrot\\Processor\\Doctrine\\ObjectManagerProcessor', $h);
      › $i->setExtras([]);
      arguments: {
        $processorClass: "Swarrot\Processor\Doctrine\ObjectManagerProcessor"
        $managerRegistry: Doctrine\Bundle\MongoDBBundle\ManagerRegistry {#522 …}
      }
    }
    /var/www/MY_APP/var/cache/dev/ContainerE16VOet/App_KernelDevDebugContainer.php:197 { …}
    /var/www/MY_APP/vendor/symfony/dependency-injection/Container.php:441 { …}
    /var/www/MY_APP/vendor/symfony/dependency-injection/Argument/ServiceLocator.php:40 { …}
    /var/www/MY_APP/vendor/symfony/console/CommandLoader/ContainerCommandLoader.php:45 { …}
    /var/www/MY_APP/vendor/symfony/console/Application.php:527 { …}
    /var/www/MY_APP/vendor/symfony/console/Application.php:616 { …}
    /var/www/MY_APP/vendor/symfony/framework-bundle/Console/Application.php:116 { …}
    /var/www/MY_APP/vendor/symfony/console/Application.php:230 { …}
    /var/www/MY_APP/vendor/symfony/framework-bundle/Console/Application.php:82 { …}
    /var/www/MY_APP/vendor/symfony/console/Application.php:142 { …}
    /var/www/MY_APP/bin/console:42 { …}
  }
}
```

Namespace `Doctrine\Common\Persistence` has been removed in `doctrine/persistence` lib in v2 https://github.com/doctrine/persistence/pull/106 https://github.com/doctrine/persistence/releases/tag/2.0.0

I've updated processor to be compatible with new version of lib. 

