### PR TITLE
php-amqplib: use AMQPStreamConnection instead of AMQPConnection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ matrix:
     - php: 7.3
     - php: 7.2
       env: COMPOSER_FLAGS="--prefer-lowest --prefer-stable" PHPUNIT_FLAGS="--exclude-group legacy" # See https://github.com/symfony/symfony/issues/22515
-    - php: 7.3
+    - php: 7.4
       env: LIBRABBITMQ_VERSION="master"
+      dist: focal
     - php: 7.3
       env: DEPENDENCIES=dev COMPOSER_FLAGS="--prefer-stable"
 

--- a/Broker/AmqpLibFactory.php
+++ b/Broker/AmqpLibFactory.php
@@ -3,8 +3,8 @@
 namespace Swarrot\SwarrotBundle\Broker;
 
 use PhpAmqpLib\Channel\AMQPChannel;
-use PhpAmqpLib\Connection\AMQPConnection;
 use PhpAmqpLib\Connection\AMQPSSLConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use Swarrot\Broker\MessageProvider\MessageProviderInterface;
 use Swarrot\Broker\MessageProvider\PhpAmqpLibMessageProvider;
 use Swarrot\Broker\MessagePublisher\MessagePublisherInterface;
@@ -108,7 +108,7 @@ class AmqpLibFactory implements FactoryInterface
                 $ssl_opts
             );
         } else {
-            $conn = new AMQPConnection(
+            $conn = new AMQPStreamConnection(
                 $this->connections[$connection]['host'],
                 $this->connections[$connection]['port'],
                 $this->connections[$connection]['login'],

--- a/Tests/Broker/AmqpLibFactoryTest.php
+++ b/Tests/Broker/AmqpLibFactoryTest.php
@@ -11,7 +11,7 @@ class AmqpLibFactoryTest extends TestCase
 
     protected function setUp(): void
     {
-        if (!class_exists('PhpAmqpLib\Connection\AMQPConnection')) {
+        if (!class_exists('PhpAmqpLib\Connection\AMQPStreamConnection')) {
             $this->markTestSkipped('The php-amqplib/php-amqplib package is not available');
         }
 


### PR DESCRIPTION
**Fix compatibility with php-amqplib version 3.**
In this version class AMQPConnection was dropped, leading to the
following error:
> In AmqpLibFactory.php line 111:
>  Attempted to load class "AMQPConnection" from namespace "PhpAmqpLib\Connection".

For the following reasons, AMQPStreamConnection can be safely used
instead of AMQPConnection when using php-amqplib:
 - Since 2013, AMQPConnection is an alias of AMQPStreamConnection [1]
 - AMQPConnection is also deprecated since november 2014 [2]

Moreover, it allows compatibility with PHP 8.0 \o/

----
**CI:**
I also needed to fix CI for tests with LibRabbitMQ version `master`.

----

[1] https://github.com/php-amqplib/php-amqplib/commit/68a26730b46c9a87c1c76c297bc2c752f736be0e#diff-f335edbdd39701e7e2a7b44a647a54e0010f15508a06baca2a3db1836549f3eb
[2] https://github.com/php-amqplib/php-amqplib/commit/64eb289c9f5721daa2bd3ad0f333c5b738580843#diff-f335edbdd39701e7e2a7b44a647a54e0010f15508a06baca2a3db1836549f3eb