### PR TITLE
fix(pecl): Check if the connection is connected when creating a channel

### DIFF
--- a/Broker/PeclFactory.php
+++ b/Broker/PeclFactory.php
@@ -136,6 +136,10 @@ class PeclFactory implements FactoryInterface
             $this->amqpConnections[$connection]->connect();
         }
 
+        if (!$this->amqpConnections[$connection]->isConnected()) {
+            $this->amqpConnections[$connection]->connect();
+        }
+
         return new \AMQPChannel($this->amqpConnections[$connection]);
     }
 }


### PR DESCRIPTION
If the connection is not connected, the constructor of the AMQPChannel throws an exception stating : `Could not create channel. No connection available.`

In particular, if the first connect() method call failed, the ampqconnection is stored in the class even if the connection is not opened and all future calls to the getChannel() method didn't try to reconnect, failing with the above exception