### PR TITLE
Define command description as static property

### DIFF
--- a/Command/SwarrotCommand.php
+++ b/Command/SwarrotCommand.php
@@ -33,6 +33,9 @@ class SwarrotCommand extends Command
     /** @var array */
     protected $aliases;
 
+    /** @var string */
+    protected static $defaultDescription = 'Consume messages from a given queue';
+
     public function __construct(
         FactoryInterface $swarrotFactory,
         string $name,
@@ -65,7 +68,7 @@ class SwarrotCommand extends Command
         $this
             ->setName('swarrot:consume:'.$this->name)
             ->setAliases($this->aliases)
-            ->setDescription('Consume messages from a given queue')
+            ->setDescription(self::$defaultDescription)
             ->addArgument('queue', InputArgument::OPTIONAL, 'Queue to consume', $this->queue)
             ->addArgument('connection', InputArgument::OPTIONAL, 'Connection to use', $this->connectionName)
             ->addOption(


### PR DESCRIPTION
This allows Symfony to make the command lazy-loadable and thus avoiding instantiation of every processors only to list application's commands.
See https://github.com/symfony/symfony/pull/39851 for more info