### PR TITLE
Allow using the latest version of PHPUnit

### DIFF
--- a/Tests/Command/SwarrotCommandTest.php
+++ b/Tests/Command/SwarrotCommandTest.php
@@ -66,7 +66,7 @@ class SwarrotCommandTest extends TestCase
         }
     }
 
-    public function it_merges_arguments_from_config_and_command_line_dataprovider()
+    public static function it_merges_arguments_from_config_and_command_line_dataprovider()
     {
         return [
             'No option from the command line and no extras' => [

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php-amqplib/php-amqplib": "^2.9|^3.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/phpstan": "^1.2",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.5|^10.0",
         "symfony/event-dispatcher": "^4.4|^5.4|^6.0",
         "symfony/phpunit-bridge": "^4.4|^5.4|^6.0"
     },


### PR DESCRIPTION
While it does not mean that we can use the latest features, it means we can spot and address deprecations earlier. It also means the output of composer outdated is smaller, which in turns allows us to spot where work is needed more easily.
Note that it also means running phpunit now also produces a warning about validating against a deprecated schema, and I do not think we can address it until we drop support for PHP <= 8.1, since PHPUnit 10 requires PHP 8.1+