### PR TITLE
Remove usage of the deprecated base extension from HttpKernel

### DIFF
--- a/DependencyInjection/SwarrotExtension.php
+++ b/DependencyInjection/SwarrotExtension.php
@@ -5,9 +5,9 @@ namespace Swarrot\SwarrotBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * SwarrotExtension.


### PR DESCRIPTION
The base extension available in HttpKernel only adds support for registering some classes to be added in the cache warmer of the doctrine/annotations parser, compared to the base class of the DI component.
As annotations are not supported anymore in Symfony 7, this base class has been deprecated in Symfony 7.1.
As this bundle does not rely on the extra feature, it can use the base class from DI directly.