### PR TITLE
Fix PHP deprecation for implicit nullable types

### DIFF
--- a/Broker/PeclFactory.php
+++ b/Broker/PeclFactory.php
@@ -33,7 +33,7 @@ class PeclFactory implements FactoryInterface
     /** @var array */
     protected $amqpConnections = [];
 
-    public function __construct(LoggerInterface $logger = null, bool $publisherConfirms = false, float $timeout = 0.0)
+    public function __construct(?LoggerInterface $logger = null, bool $publisherConfirms = false, float $timeout = 0.0)
     {
         $this->logger = $logger ?: new NullLogger();
         $this->publisherConfirms = $publisherConfirms;

--- a/Broker/Publisher.php
+++ b/Broker/Publisher.php
@@ -19,7 +19,7 @@ class Publisher
     /** @var LoggerInterface */
     protected $logger;
 
-    public function __construct(FactoryInterface $factory, EventDispatcherInterface $eventDispatcher, array $messageTypes = [], LoggerInterface $logger = null)
+    public function __construct(FactoryInterface $factory, EventDispatcherInterface $eventDispatcher, array $messageTypes = [], ?LoggerInterface $logger = null)
     {
         $this->factory = $factory;
         $this->eventDispatcher = $eventDispatcher;

--- a/Command/SwarrotCommand.php
+++ b/Command/SwarrotCommand.php
@@ -40,7 +40,7 @@ class SwarrotCommand extends Command
         ProcessorInterface $processor,
         array $processorConfigurators,
         array $extras,
-        string $queue = null,
+        ?string $queue = null,
         array $aliases = []
     ) {
         $this->swarrotFactory = $swarrotFactory;

--- a/DataCollector/SwarrotDataCollector.php
+++ b/DataCollector/SwarrotDataCollector.php
@@ -13,7 +13,7 @@ class SwarrotDataCollector extends DataCollector
     /**
      * @param \Throwable|\Exception $exception
      */
-    public function collect(Request $request, Response $response, \Throwable $exception = null): void
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
     {
     }
 


### PR DESCRIPTION
This deprecation is coming in PHP 8.4