### PR TITLE
Use a dev dependency for php-cs-fixer

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -5,17 +5,24 @@ jobs:
     name: PHP-CS-Fixer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - name: PHP-CS-Fixer
-        uses: docker://oskarstark/php-cs-fixer-ga
+      - uses: actions/checkout@v4
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
         with:
-          args: --dry-run
+            coverage: "none"
+            php-version: "8.3"
+
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v2"
+
+      - name: PHP-CS-Fixer
+        run: vendor/bin/php-cs-fixer fix --dry-run
 
   phpstan:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout code"
-        uses: "actions/checkout@master"
+        uses: "actions/checkout@v4"
 
       - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vendor/
 bin/phpunit
+.php-cs-fixer.cache
 .phpunit.result.cache
 composer.lock
 bin/doctrine-dbal

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -14,7 +14,7 @@ $config
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
         'no_superfluous_phpdoc_tags' => [
-            'allow_mixed' => true, # PHPStan will complain about missing types otherwise
+            'allow_mixed' => true, // PHPStan will complain about missing types otherwise
         ],
     ])
     ->setFinder($finder)

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "require-dev": {
         "doctrine/common": "^2.9|^3.0",
         "doctrine/dbal": "^2.2|^3.0",
+        "friendsofphp/php-cs-fixer": "^3.59",
         "php-amqplib/php-amqplib": "^2.9|^3.0",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpstan/phpstan": "^1.2",


### PR DESCRIPTION
This has 2 benefits:
- it makes it easier to run it locally to do the fixes
- it gives us control over the version being used instead of running the version used in a third-party docker image.